### PR TITLE
Mark client ID const

### DIFF
--- a/source/include/signaling_data_types.h
+++ b/source/include/signaling_data_types.h
@@ -322,7 +322,7 @@ typedef struct GetSignalingChannelEndpointRequestInfo
 typedef struct GetIceServerConfigRequestInfo
 {
     SignalingChannelArn_t channelArn;
-    char * pClientId;
+    const char * pClientId;
     size_t clientIdLength;
 } GetIceServerConfigRequestInfo_t;
 
@@ -335,7 +335,7 @@ typedef struct JoinStorageSessionRequestInfo
 {
     SignalingChannelArn_t channelArn;
     SignalingRole_t role;
-    char * pClientId;
+    const char * pClientId;
     size_t clientIdLength;
 } JoinStorageSessionRequestInfo_t;
 


### PR DESCRIPTION
Mark client ID const in "get ICE server condif request" and "join storage session request" to avoid changing user data unexpectly.